### PR TITLE
Bump version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iso_country"
-version = "0.1.1"
+version = "0.1.3"
 authors = ["Piotr Zolnierek <pzolnierek@gmail.com>"]
 license = "MIT"
 description = "ISO3166-1 countries"


### PR DESCRIPTION
Would you mind uploading new version to crates.io?
It's 0.1.3 not 0.1.2 cause 0.1.2 is already on crates for some reason.